### PR TITLE
Export __version__ in the __init__.py

### DIFF
--- a/pixel_sizes/__init__.py
+++ b/pixel_sizes/__init__.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass
 
+# https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
+from ._version import __version__
+
 
 @dataclass(frozen=True)
 class Size:
@@ -26,4 +29,4 @@ SIZES = {
 }
 
 
-__all__ = ["Size", "SIZES"]
+__all__ = ["Size", "SIZES", "__version__"]


### PR DESCRIPTION
- I've created _version.py file but it's not working as expected.
- This PR will export `__version__` in the `__init__.py` file.
