### PR TITLE
Tighten Ruff lint rules

### DIFF
--- a/pixel_sizes/__init__.py
+++ b/pixel_sizes/__init__.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
 import math
+from dataclasses import dataclass
 
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
 from ._version import __version__
@@ -36,7 +36,8 @@ class Size:
         return Size(self.height, self.width)
 
     def scale(self, factor: int) -> "Size":
-        """Returns a new Size object with the width and height scaled by the given factor.
+        """Returns a new Size object with scaled width and height.
+
         Example: 1920x1080, factor=2 => 3840x2160
         """
         return Size(self.width * factor, self.height * factor)
@@ -98,4 +99,4 @@ SIZES = {
     "UHDTV2": Size(7680, 4320),
 }
 
-__all__ = ["Size", "SIZES", "__version__"]
+__all__ = ["SIZES", "Size", "__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,5 +73,36 @@ ignore_missing_imports = false
 [tool.ruff]
 line-length = 79
 
+[tool.ruff.lint]
+select = [
+    "A",
+    "ANN",
+    "ARG",
+    "B",
+    "C4",
+    "C90",
+    "COM",
+    "E",
+    "F",
+    "I",
+    "PERF",
+    "PLE",
+    "PTH",
+    "RET",
+    "RUF",
+    "S",
+    "SIM",
+    "SLOT",
+    "UP",
+    "W",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "ANN",
+    "D",
+    "S101",
+]
+
 [tool.flake8]
 ignore = "E203"

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,4 +1,4 @@
-from pixel_sizes import Size, SIZES
+from pixel_sizes import SIZES, Size
 
 
 def test_sizes() -> None:


### PR DESCRIPTION
## Summary

Tighten the Ruff lint configuration with a stricter, low-friction rule set.

## Changes

- enable a broader set of non-framework-specific Ruff rules
- keep test files practical with targeted per-file ignores where needed
- update code that was auto-fixable or low-cost to adjust manually

## Verification

- `uv run poe check`
- `uv run poe test`
