### PR TITLE
Add Ruff McCabe complexity limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,5 +104,8 @@ select = [
     "S101",
 ]
 
+[tool.ruff.lint.mccabe]
+max-complexity = 1
+
 [tool.flake8]
 ignore = "E203"


### PR DESCRIPTION
## Summary
- add Ruff McCabe `max-complexity = 1`

## Testing
- `uv run poe check`
- `uv run poe test`

## Notes
- `uv run poe build` currently fails because `build` is not installed in the project environment