### PR TITLE
Pin PyPI publish workflow action refs

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,16 +19,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.python_version }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies
         run: |
@@ -39,7 +39,7 @@ jobs:
         run: uv build
 
       - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
           user: __token__
@@ -48,7 +48,7 @@ jobs:
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Pin the PyPI publish workflow actions to full commit SHAs.
- Keep the original action tag or branch names as inline comments for future updates.
- Leave existing `contents: read` workflow and job permissions unchanged.

## Validation

- `git diff --check`
- YAML parse for `.github/workflows/pypi-publish.yml`
- `actionlint .github/workflows/pypi-publish.yml`
- `uv sync`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`

## Notes

`uv run poe build` currently fails because the configured task runs `python -m build` while the `build` package is not installed in the development dependencies. The publish workflow itself uses `uv build`, which passes locally. Existing setuptools license deprecation warnings are unrelated to this workflow pinning change.