### PR TITLE
Pin read-only reusable CI workflows

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@3717c78af3a5e594b7a81b063276e15fac7e08fc # main


### PR DESCRIPTION
## Summary
- set the test workflow token scope to read-only contents access
- pin the read-only reusable spellcheck workflow to a commit SHA

## Verification
- actionlint .github/workflows/python-test.yml .github/workflows/spellcheck.yml
- git diff --check
- gh api repos/kitsuyui/gh-actions-workflows/commits/3717c78af3a5e594b7a81b063276e15fac7e08fc --jq .sha