### PR TITLE
Remove broken package-data glob entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 Homepage = "https://github.com/kitsuyui/python-pixel-sizes"
 
 [tool.setuptools]
-package-data = { "pixel_sizes" = ["py.typed"], "*" = ["README.md, LICENSE"] }
+package-data = { "pixel_sizes" = ["py.typed"] }
 package-dir = { "pixel_sizes" = "pixel_sizes" }
 
 [tool.setuptools_scm]


### PR DESCRIPTION
## Summary

The `"*" = ["README.md, LICENSE"]` entry under `[tool.setuptools] package-data` in `pyproject.toml` was a single comma-separated string used as a glob pattern. setuptools does not split such strings, so the entry matched no files and silently distributed nothing.

It was also unreachable in practice: `package-dir = { "pixel_sizes" = "pixel_sizes" }` resolves package-data globs relative to `pixel_sizes/`, while `README.md` and `LICENSE` live at the repository root.

README.md and LICENSE remain distributed via PEP 621 metadata (`[project] readme = {file = "README.md", ...}` / `license = {file = "LICENSE"}`), which already places LICENSE in `*.dist-info/licenses/` of the wheel and includes README.md in the sdist root.

## Why

Aligns the configured intent with actual packaging behavior. Removing the broken entry prevents the same `["a, b"]` typo, or future package-data entries that reference root files outside the package directory, from being silently ignored.

## Verification

Local `uv build` produced both `pixel_sizes-0.3.0.tar.gz` and `pixel_sizes-0.3.0-py3-none-any.whl` and confirmed:

- sdist contains `LICENSE` and `README.md` at the archive root.
- wheel contains `pixel_sizes/py.typed` (the `package-data = { "pixel_sizes" = ["py.typed"] }` entry remains effective) and `pixel_sizes-0.3.0.dist-info/licenses/LICENSE`.

## Test plan

- [ ] CI `tests` workflow passes
- [ ] CI `octocov` coverage workflow passes