### PR TITLE
Pin python-test workflow action refs to 40-character commit SHAs

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -21,16 +21,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{ matrix.python }}"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

Pin the three external `uses:` references in `.github/workflows/python-test.yml` to 40-character commit SHAs:

| File | Before | After |
| --- | --- | --- |
| `python-test.yml:24` | `actions/checkout@v6` | `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` |
| `python-test.yml:28` | `actions/setup-python@v6` | `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6` |
| `python-test.yml:33` | `astral-sh/setup-uv@v7` | `astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7` |

Each pinned SHA is already in use by `pypi-publish.yml` and `octocov.yml` in this same repository, so the pinned digest matches what the rest of CI is already exercising.

Tag references (`@v6`, `@v7`) let upstream silently move content under our CI pipeline. Pinning to a 40-character SHA fixes the supply-chain input.

Renovate already extends `helpers:pinGitHubActionDigests` via `local>kitsuyui/renovate-config`, so future digest updates continue through automated PRs.

## Test plan

- [x] `git diff` confirms only the three `uses:` lines change
- [x] All three SHAs match the existing pinned references in `pypi-publish.yml` / `octocov.yml`