### PR TITLE
Accept float factor in scale() and add deprecation warning to aspect_ratio_two()

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ from pixel_sizes import SIZES
 SIZES['Full HD'].width   # 1920
 SIZES['Full HD'].height  # 1080
 SIZES['Full HD'].aspect_ratio()    # 16/9 == 1.7777777777777777
-SIZES['Full HD'].aspect_ratio_two()  # (16, 9)
+SIZES['Full HD'].aspect_ratio_fraction()  # (16, 9)
 SIZES['Full HD'].rotate()  # Size(width=1080, height=1920)
 SIZES['Full HD'].scale(2)  # Size(width=3840, height=2160)
 ```
@@ -24,9 +24,9 @@ SIZES['Full HD'].scale(2)  # Size(width=3840, height=2160)
 | `width: int` | Width in pixels |
 | `height: int` | Height in pixels |
 | `aspect_ratio() -> float` | Width / height as a float |
-| `aspect_ratio_two() -> tuple[int, int]` | Aspect ratio reduced to lowest terms, e.g. `(16, 9)` |
+| `aspect_ratio_fraction() -> tuple[int, int]` | Aspect ratio reduced to lowest terms, e.g. `(16, 9)` |
 | `rotate() -> Size` | New `Size` with width and height swapped |
-| `scale(factor: int) -> Size` | New `Size` multiplied by *factor* |
+| `scale(factor: int \| float) -> Size` | New `Size` multiplied by *factor* |
 
 ### `SIZES`
 

--- a/pixel_sizes/__init__.py
+++ b/pixel_sizes/__init__.py
@@ -32,13 +32,18 @@ class Size:
         """
         return self.width / self.height
 
-    def aspect_ratio_two(self) -> tuple[int, int]:
-        """Returns the aspect ratio as a tuple of integers.
+    def aspect_ratio_fraction(self) -> tuple[int, int]:
+        """Returns the reduced aspect ratio as a (numerator, denominator).
+
         Example: 1920x1080 => (16, 9)
         """
         _ = self.width / self.height
         gcd = math.gcd(self.width, self.height)
         return self.width // gcd, self.height // gcd
+
+    def aspect_ratio_two(self) -> tuple[int, int]:
+        """Deprecated: use aspect_ratio_fraction() instead."""
+        return self.aspect_ratio_fraction()
 
     def rotate(self) -> "Size":
         """Returns a new Size object with the width and height swapped.

--- a/pixel_sizes/__init__.py
+++ b/pixel_sizes/__init__.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from dataclasses import dataclass
 
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
@@ -43,6 +44,11 @@ class Size:
 
     def aspect_ratio_two(self) -> tuple[int, int]:
         """Deprecated: use aspect_ratio_fraction() instead."""
+        warnings.warn(
+            "aspect_ratio_two() is deprecated; use aspect_ratio_fraction().",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.aspect_ratio_fraction()
 
     def rotate(self) -> "Size":

--- a/pixel_sizes/__init__.py
+++ b/pixel_sizes/__init__.py
@@ -60,9 +60,14 @@ class Size:
     def scale(self, factor: int | float) -> "Size":  # noqa: C901
         """Returns a new Size object with scaled width and height.
 
-        Non-integer factors are rounded to the nearest integer pixel.
+        Non-integer factors are rounded using Python's built-in round(),
+        which applies round-half-to-even (banker's rounding, IEEE 754).
+        When a scaled dimension lands exactly on 0.5, it rounds toward the
+        nearest even integer rather than always rounding up.
+
         Example: 1920x1080, factor=2 => 3840x2160
         Example: 1920x1080, factor=0.5 => 960x540
+        Example: Size(3, 2).scale(1.5) => Size(4, 3)  # 4.5 rounds to 4 (even)
         """
         if factor <= 0:
             raise ValueError(f"scale factor must be positive, got {factor!r}")

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -40,27 +40,28 @@ def test_size_rotate() -> None:
 def test_size_aspect_ratio() -> None:
     size = Size(1920, 1080)
     assert size.aspect_ratio() == 16 / 9
-    assert size.aspect_ratio_two() == (16, 9)
+    assert size.aspect_ratio_fraction() == (16, 9)
+    assert size.aspect_ratio_two() == (16, 9)  # backward compat alias
 
     size = Size(1280, 720)
     assert size.aspect_ratio() == 16 / 9
-    assert size.aspect_ratio_two() == (16, 9)
-    assert SIZES["Full HD"].aspect_ratio_two() == (16, 9)
-    assert SIZES["HD"].aspect_ratio_two() == (16, 9)
-    assert SIZES["QCIF"].aspect_ratio_two() == (11, 9)
-    assert SIZES["QVGA"].aspect_ratio_two() == (4, 3)
-    assert SIZES["HVGA"].aspect_ratio_two() == (3, 2)
-    assert SIZES["DCGA"].aspect_ratio_two() == (8, 5)
-    assert SIZES["VGA"].aspect_ratio_two() == (4, 3)
-    assert SIZES["SVGA"].aspect_ratio_two() == (4, 3)
-    assert SIZES["DoubleVGA"].aspect_ratio_two() == (3, 2)
-    assert SIZES["XGA"].aspect_ratio_two() == (4, 3)
-    assert SIZES["WXGA"].aspect_ratio_two() == (8, 5)
-    assert SIZES["FWXGA"].aspect_ratio_two() == (683, 384)
-    assert SIZES["WXGA+"].aspect_ratio_two() == (8, 5)
-    assert SIZES["HD+"].aspect_ratio_two() == (16, 9)
+    assert size.aspect_ratio_fraction() == (16, 9)
+    assert SIZES["Full HD"].aspect_ratio_fraction() == (16, 9)
+    assert SIZES["HD"].aspect_ratio_fraction() == (16, 9)
+    assert SIZES["QCIF"].aspect_ratio_fraction() == (11, 9)
+    assert SIZES["QVGA"].aspect_ratio_fraction() == (4, 3)
+    assert SIZES["HVGA"].aspect_ratio_fraction() == (3, 2)
+    assert SIZES["DCGA"].aspect_ratio_fraction() == (8, 5)
+    assert SIZES["VGA"].aspect_ratio_fraction() == (4, 3)
+    assert SIZES["SVGA"].aspect_ratio_fraction() == (4, 3)
+    assert SIZES["DoubleVGA"].aspect_ratio_fraction() == (3, 2)
+    assert SIZES["XGA"].aspect_ratio_fraction() == (4, 3)
+    assert SIZES["WXGA"].aspect_ratio_fraction() == (8, 5)
+    assert SIZES["FWXGA"].aspect_ratio_fraction() == (683, 384)
+    assert SIZES["WXGA+"].aspect_ratio_fraction() == (8, 5)
+    assert SIZES["HD+"].aspect_ratio_fraction() == (16, 9)
     assert SIZES["HD+"] == SIZES["WXGA++"]
-    assert SIZES["WXGA++"].aspect_ratio_two() == (16, 9)
+    assert SIZES["WXGA++"].aspect_ratio_fraction() == (16, 9)
 
 
 def test_size_scale() -> None:

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -41,7 +41,8 @@ def test_size_aspect_ratio() -> None:
     size = Size(1920, 1080)
     assert size.aspect_ratio() == 16 / 9
     assert size.aspect_ratio_fraction() == (16, 9)
-    assert size.aspect_ratio_two() == (16, 9)  # backward compat alias
+    with pytest.warns(DeprecationWarning):
+        assert size.aspect_ratio_two() == (16, 9)  # backward compat alias
 
     size = Size(1280, 720)
     assert size.aspect_ratio() == 16 / 9

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -79,6 +79,8 @@ def test_size_scale() -> None:
     # float factor: rounds to nearest integer pixel
     assert size.scale(0.5) == Size(960, 540)
     assert size.scale(1.5) == Size(2880, 1620)
+    # banker's rounding (round-half-to-even): 4.5 rounds to 4, not 5
+    assert Size(3, 2).scale(1.5) == Size(4, 3)
 
 
 def test_size_scale_invalid_factor() -> None:


### PR DESCRIPTION
## Summary

- `scale(factor)` now accepts `int | float`; non-integer factors are rounded to the nearest integer pixel.
- `aspect_ratio_fraction()` is introduced as the primary name for the reduced-ratio method. `aspect_ratio_two()` is kept as a backward-compatible alias that delegates to it and now emits a `DeprecationWarning` at every call site.
- README updated to show `aspect_ratio_fraction()` in the usage example.

## Changes

| File | Change |
|---|---|
| `pixel_sizes/__init__.py` | `scale`: `int` → `int \| float`; add `aspect_ratio_fraction()`; `aspect_ratio_two()` delegates to it and emits `DeprecationWarning` |
| `tests/test_basis.py` | tests migrated to `aspect_ratio_fraction()`; float scale tests added; `aspect_ratio_two()` call wrapped in `pytest.warns(DeprecationWarning)` |
| `README.md` | usage example updated |

## Motivation

Callers that rely only on the docstring have no runtime signal to migrate away from `aspect_ratio_two()`. Adding `warnings.warn(..., DeprecationWarning, stacklevel=2)` makes the deprecation visible at call time and detectable by `-W error::DeprecationWarning` in test suites.

## Verification

- `uv run poe format` — no changes
- `uv run poe check` — ruff: all checks passed, mypy: no issues (4 files)
- `uv run poe test` — 4 passed
- `uvx vulture pixel_sizes tests` — 0 findings

## Trade-offs

- `aspect_ratio_two()` now emits `DeprecationWarning` on every call. Callers running tests with `-W error::DeprecationWarning` will see failures until they migrate to `aspect_ratio_fraction()`. This is intentional.
- `scale()` with a float factor rounds sub-pixel results via `round()`. Callers needing exact fractional arithmetic should compute before calling `Size`.
