### PR TITLE
fix: make SIZES read-only with MappingProxyType

### DIFF
--- a/pixel_sizes/__init__.py
+++ b/pixel_sizes/__init__.py
@@ -1,5 +1,6 @@
 import math
 from dataclasses import dataclass
+from types import MappingProxyType
 
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
 from ._version import __version__
@@ -58,62 +59,64 @@ class Size:
         return Size(round(self.width * factor), round(self.height * factor))
 
 
-SIZES = {
-    "480p": Size(854, 480),
-    "360p": Size(640, 360),
-    "240p": Size(426, 240),
-    "144p": Size(256, 144),
-    "720p": Size(1280, 720),
-    "Full HD": Size(1920, 1080),
-    "HD 1080p": Size(1920, 1080),
-    "1080p": Size(1920, 1080),
-    "1080i": Size(1920, 1080),
-    "HD": Size(1280, 720),
-    "QCIF": Size(176, 144),
-    "QVGA": Size(320, 240),
-    "HVGA": Size(480, 320),
-    "DCGA": Size(640, 400),
-    "VGA": Size(640, 480),
-    "SVGA": Size(800, 600),
-    "WSVGA": Size(
-        1024, 600,
-    ),  # 2 versions exist: 1024x600 and 1024x576; using 1024x600
-    "DoubleVGA": Size(960, 640),
-    "XGA": Size(1024, 768),
-    "HD 720p": Size(1280, 720),
-    "WXGA": Size(1280, 800),
-    "FWXGA": Size(1366, 768),
-    "WXGA+": Size(1440, 900),
-    "HD+": Size(1600, 900),
-    "WXGA++": Size(1600, 900),
-    "SXGA+": Size(1400, 1050),
-    "WSXGA+": Size(1680, 1050),
-    "UXGA": Size(1600, 1200),
-    "WQHD": Size(2560, 1440),
-    # https://en.wikipedia.org/wiki/2K_resolution
-    "DCI 2K": Size(2048, 1080),
-    "DCI 2K (flat cropped)": Size(1998, 1080),
-    "DCI 2K (CinemaScope cropped)": Size(2048, 858),
-    "QXGA": Size(2048, 1536),
-    "WQXGA": Size(2560, 1600),
-    "WUXGA": Size(1920, 1200),
-    "QWXGA": Size(2048, 1152),
-    "QUXGA": Size(3200, 2400),
-    "QUXGA Wide": Size(3840, 2400),
-    # https://en.wikipedia.org/wiki/4K_resolution
-    "DCI 4K": Size(4096, 2160),
-    "DCI 4K (flat cropped)": Size(3996, 2160),
-    "DCI 4K (CinemaScope cropped)": Size(4096, 1716),
-    "4K UHD": Size(3840, 2160),
-    "4K UHDTV": Size(3840, 2160),
-    "UHDTV1": Size(3840, 2160),
-    "2160p": Size(3840, 2160),
-    # https://en.wikipedia.org/wiki/5K_resolution
-    "5K": Size(5120, 2880),
-    "5K2K": Size(5120, 2160),
-    # https://en.wikipedia.org/wiki/8K_resolution
-    "8K UHD": Size(7680, 4320),
-    "UHDTV2": Size(7680, 4320),
-}
+SIZES: MappingProxyType[str, Size] = MappingProxyType(
+    {
+        "480p": Size(854, 480),
+        "360p": Size(640, 360),
+        "240p": Size(426, 240),
+        "144p": Size(256, 144),
+        "720p": Size(1280, 720),
+        "Full HD": Size(1920, 1080),
+        "HD 1080p": Size(1920, 1080),
+        "1080p": Size(1920, 1080),
+        "1080i": Size(1920, 1080),
+        "HD": Size(1280, 720),
+        "QCIF": Size(176, 144),
+        "QVGA": Size(320, 240),
+        "HVGA": Size(480, 320),
+        "DCGA": Size(640, 400),
+        "VGA": Size(640, 480),
+        "SVGA": Size(800, 600),
+        "WSVGA": Size(
+            1024, 600,
+        ),  # 2 versions exist: 1024x600 and 1024x576; using 1024x600
+        "DoubleVGA": Size(960, 640),
+        "XGA": Size(1024, 768),
+        "HD 720p": Size(1280, 720),
+        "WXGA": Size(1280, 800),
+        "FWXGA": Size(1366, 768),
+        "WXGA+": Size(1440, 900),
+        "HD+": Size(1600, 900),
+        "WXGA++": Size(1600, 900),
+        "SXGA+": Size(1400, 1050),
+        "WSXGA+": Size(1680, 1050),
+        "UXGA": Size(1600, 1200),
+        "WQHD": Size(2560, 1440),
+        # https://en.wikipedia.org/wiki/2K_resolution
+        "DCI 2K": Size(2048, 1080),
+        "DCI 2K (flat cropped)": Size(1998, 1080),
+        "DCI 2K (CinemaScope cropped)": Size(2048, 858),
+        "QXGA": Size(2048, 1536),
+        "WQXGA": Size(2560, 1600),
+        "WUXGA": Size(1920, 1200),
+        "QWXGA": Size(2048, 1152),
+        "QUXGA": Size(3200, 2400),
+        "QUXGA Wide": Size(3840, 2400),
+        # https://en.wikipedia.org/wiki/4K_resolution
+        "DCI 4K": Size(4096, 2160),
+        "DCI 4K (flat cropped)": Size(3996, 2160),
+        "DCI 4K (CinemaScope cropped)": Size(4096, 1716),
+        "4K UHD": Size(3840, 2160),
+        "4K UHDTV": Size(3840, 2160),
+        "UHDTV1": Size(3840, 2160),
+        "2160p": Size(3840, 2160),
+        # https://en.wikipedia.org/wiki/5K_resolution
+        "5K": Size(5120, 2880),
+        "5K2K": Size(5120, 2160),
+        # https://en.wikipedia.org/wiki/8K_resolution
+        "8K UHD": Size(7680, 4320),
+        "UHDTV2": Size(7680, 4320),
+    },
+)
 
 __all__ = ["SIZES", "Size", "__version__"]


### PR DESCRIPTION
## Summary

`SIZES` in `pixel_sizes/__init__.py` was a plain `dict`, allowing callers to modify it in place. Since `SIZES` is a module-level constant intended to be read-only, any mutation silently propagates to all subsequent reads within the same process.

This PR wraps `SIZES` in `types.MappingProxyType` to make it immutable at runtime.

## Changes

- `pixel_sizes/__init__.py` — add `from types import MappingProxyType`; wrap the dict literal with `MappingProxyType({...})`; annotate as `MappingProxyType[str, Size]`

## Motivation

A caller doing `SIZES["custom"] = Size(800, 480)` or `del SIZES["VGA"]` would silently affect all downstream code reading `SIZES` in the same process. With `MappingProxyType`, any attempted write raises `TypeError` at the mutation site, making the error visible immediately rather than at the reading site.

## Verification

- `ruff check`: all checks passed
- `mypy`: no issues found (strict mode)
- `pytest`: 4 passed

## Trade-offs

`MappingProxyType` does not implement `dict` directly, so callers that type-annotate `SIZES` as `dict[str, Size]` would see a mypy error. Callers should annotate with `Mapping[str, Size]` or `MappingProxyType[str, Size]`. Read-only operations (`SIZES["VGA"]`, `"VGA" in SIZES`, `for k in SIZES`) work identically to `dict`.
