### PR TITLE
Document banker's rounding in scale() docstring and add half-integer test

### DIFF
--- a/pixel_sizes/__init__.py
+++ b/pixel_sizes/__init__.py
@@ -48,9 +48,15 @@ class Size:
 
     def scale(self, factor: int | float) -> "Size":
         """Returns a new Size object with scaled width and height.
-        Non-integer factors are rounded to the nearest integer pixel.
+
+        Non-integer factors are rounded using Python's built-in round(),
+        which applies round-half-to-even (banker's rounding, IEEE 754).
+        When a scaled dimension lands exactly on 0.5, it rounds toward the
+        nearest even integer rather than always rounding up.
+
         Example: 1920x1080, factor=2 => 3840x2160
         Example: 1920x1080, factor=0.5 => 960x540
+        Example: Size(3, 2).scale(1.5) => Size(4, 3)  # 4.5 rounds to 4 (even)
         """
         return Size(round(self.width * factor), round(self.height * factor))
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -59,3 +59,5 @@ def test_size_scale() -> None:
     # float factor: rounds to nearest integer pixel
     assert size.scale(0.5) == Size(960, 540)
     assert size.scale(1.5) == Size(2880, 1620)
+    # banker's rounding (round-half-to-even): 4.5 rounds to 4, not 5
+    assert Size(3, 2).scale(1.5) == Size(4, 3)


### PR DESCRIPTION
## Summary

- Clarify that `scale()` uses Python's `round()`, which implements round-half-to-even (banker's rounding, IEEE 754), not the traditional round-half-up.
- Add an explicit example in the docstring showing that `Size(3, 2).scale(1.5)` produces `Size(4, 3)` because `4.5` rounds to `4` (nearest even), not `5`.
- Add a test that pins this behavior so callers have a documented contract to rely on.

## Motivation

The previous docstring stated "Non-integer factors are rounded to the nearest integer pixel," which readers familiar with traditional rounding may interpret as round-half-up. Python's `round()` follows IEEE 754 round-half-to-even, meaning `4.5` rounds to `4`, not `5`. This difference matters for callers working with odd pixel dimensions or tiles.

## Changes

| File | Change |
|---|---|
| `pixel_sizes/__init__.py` | `scale()` docstring: replace vague "rounded to the nearest integer pixel" with explicit round-half-to-even explanation and half-integer example |
| `tests/test_basis.py` | Add `Size(3, 2).scale(1.5) == Size(4, 3)` assertion to document banker's rounding |

## Verification

- `uv run poe format` — no changes
- `uv run poe check` — ruff: all checks passed, mypy: no issues (4 files)
- `uv run poe test` — 4 passed (including the new assertion)
- `uvx vulture pixel_sizes tests` — 0 findings

## Notes

This PR stacks on #210 (float factor support). It only adds documentation and a test; no behavior change.
