### PR TITLE
Fix aspect_ratio_two() to raise ZeroDivisionError when height is zero

### DIFF
--- a/pixel_sizes/__init__.py
+++ b/pixel_sizes/__init__.py
@@ -26,6 +26,7 @@ class Size:
         """Returns the aspect ratio as a tuple of integers.
         Example: 1920x1080 => (16, 9)
         """
+        _ = self.width / self.height
         gcd = math.gcd(self.width, self.height)
         return self.width // gcd, self.height // gcd
 

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pixel_sizes import SIZES, Size
 
 
@@ -39,6 +41,13 @@ def test_size_aspect_ratio() -> None:
     assert SIZES["HD+"].aspect_ratio_two() == (16, 9)
     assert SIZES["HD+"] == SIZES["WXGA++"]
     assert SIZES["WXGA++"].aspect_ratio_two() == (16, 9)
+
+
+def test_size_aspect_ratio_zero_height() -> None:
+    with pytest.raises(ZeroDivisionError):
+        Size(1920, 0).aspect_ratio()
+    with pytest.raises(ZeroDivisionError):
+        Size(1920, 0).aspect_ratio_two()
 
 
 def test_size_scale() -> None:


### PR DESCRIPTION
## Problem

`aspect_ratio()` and `aspect_ratio_two()` behave inconsistently when `height == 0`:

- `Size(1920, 0).aspect_ratio()` → raises `ZeroDivisionError` (via `width / height`)
- `Size(1920, 0).aspect_ratio_two()` → silently returns `(1, 0)` without raising

The silent return happens because `math.gcd(n, 0) == n`, which causes the GCD
division to succeed: `n // n == 1` and `0 // n == 0`. The zero denominator is
absorbed into the GCD and never appears in a denominator.

## Change

Add `_ = self.width / self.height` at the start of `aspect_ratio_two()`.
This float division raises `ZeroDivisionError` for `height == 0` before the
GCD path runs, making both methods consistent.

The fix keeps complexity at 1 (no branch added), matching the project's
`max-complexity = 1` ruff configuration.

## Verification

- `pytest`: all 5 tests pass, including the new `test_size_aspect_ratio_zero_height`
- `ruff check`: no new findings
- `mypy`: no new issues
