### PR TITLE
Clarify WSVGA comment to name both versions and the adopted one

### DIFF
--- a/pixel_sizes/__init__.py
+++ b/pixel_sizes/__init__.py
@@ -60,7 +60,9 @@ SIZES = {
     "DCGA": Size(640, 400),
     "VGA": Size(640, 480),
     "SVGA": Size(800, 600),
-    "WSVGA": Size(1024, 600),  # 2 versions
+    "WSVGA": Size(
+        1024, 600,
+    ),  # 2 versions exist: 1024x600 and 1024x576; using 1024x600
     "DoubleVGA": Size(960, 640),
     "XGA": Size(1024, 768),
     "HD 720p": Size(1280, 720),


### PR DESCRIPTION
## Problem

`SIZES["WSVGA"]` returns `Size(1024, 600)` but the inline comment `# 2 versions`
signals that multiple WSVGA definitions exist without stating which one is used.

WSVGA commonly refers to either 1024×600 or 1024×576 depending on the source.
A reader who knows both variants cannot tell from the comment which one the
library adopted, and must inspect the `Size(...)` arguments directly.

## Change

Expand the comment from `# 2 versions` to
`# 2 versions exist: 1024x600 and 1024x576; using 1024x600`
to make the adopted value and the alternative explicit.

## Verification

- `pytest`: all 4 tests pass
- `ruff check`: no findings
- `mypy`: no issues
