### PR TITLE
Use version_file for setuptools-scm output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ package-data = { "pixel_sizes" = ["py.typed"] }
 package-dir = { "pixel_sizes" = "pixel_sizes" }
 
 [tool.setuptools_scm]
-write_to = "pixel_sizes/_version.py"
+version_file = "pixel_sizes/_version.py"
 version_scheme = "only-version"
 local_scheme = "no-local-version"
 


### PR DESCRIPTION
## Summary
- replace the deprecated setuptools-scm `write_to` key with `version_file`
- keep the generated version module path unchanged

## Verification
- `uv run poe check`
- `uv run poe test`
- `uv build`
- `git diff --check`
