### PR TITLE
ci: add concurrency groups to all pull_request/push workflows

### DIFF
--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -1,6 +1,11 @@
 name: happy-commit
 on:
   - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,6 +7,10 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,11 @@
 name: Spellcheck
 on:
   - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Summary

Add top-level `concurrency` controls to all five workflows triggered by `pull_request` or `push` events so that superseded runs are automatically canceled per branch or PR.

- `octocov.yml`: add `concurrency` group with `cancel-in-progress: true`
- `python-test.yml`: add `concurrency` group with `cancel-in-progress: true`
- `happy.yml`: add `concurrency` group with `cancel-in-progress: true`
- `spellcheck.yml`: add `concurrency` group with `cancel-in-progress: true`
- `pypi-publish.yml`: add `concurrency` group with conditional `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` to avoid interrupting release builds

## Motivation

Without `concurrency` groups, rapid pushes to the same branch leave stale CI runs consuming runner time and producing failure notifications tied to outdated commits. The `cancel-in-progress` flag stops the older run as soon as a newer one starts for the same ref.

For `pypi-publish.yml`, which responds to both `pull_request` and `release` events, cancellation is limited to `pull_request` to prevent an in-flight release publish from being interrupted.

## Verification

- `actionlint` passes on all modified workflow files
- `git diff --check` reports no whitespace issues