### PR TITLE
ci: enable uv cache in setup-uv for all workflows

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: "true"
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: "true"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: "true"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Problem

The three GitHub Actions workflows (`python-test.yml`, `octocov.yml`, `pypi-publish.yml`) used `actions/setup-python` without a cache parameter and `astral-sh/setup-uv` without explicit cache settings. Since the project uses `uv` for dependency management (not pip), the relevant cache for speeding up `uv sync` is the uv cache, not the pip cache.

`setup-uv` defaults to `enable-cache: "auto"`, which skips caching on fork PRs. Explicitly setting `enable-cache: "true"` ensures consistent cache behavior across all run types.

## Change

Add `enable-cache: "true"` to `setup-uv` in all three workflows:

- `.github/workflows/python-test.yml`
- `.github/workflows/octocov.yml`
- `.github/workflows/pypi-publish.yml`

The cache key is derived from the `uv.lock` file (setup-uv default), so the cache invalidates when dependencies change.

## Verification

CI will verify the change works correctly.