### PR TITLE
fix: add coverage threshold to .octocov.yml

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,6 +2,7 @@
 coverage:
   paths:
     - coverage.xml
+  if: coverage.percentage >= 80.0
 codeToTestRatio:
   code:
     - "**/*.py"


### PR DESCRIPTION
## Summary

Add a minimum coverage threshold to `.octocov.yml` so that CI fails if
coverage drops below 80%.

Previously octocov was measuring and reporting coverage but not enforcing a
minimum. Code additions without corresponding tests would silently pass CI.
Current coverage is 100%; the 80% floor gives headroom for growth while
ensuring a meaningful gate is in place.

## Changes

- `.octocov.yml`: add `if: coverage.percentage >= 80.0` under `coverage:`

## Verification

- `uv run poe check`: all checks passed (ruff + mypy)
- `uv run pytest`: 9 passed (1 pre-existing failure unrelated to this change)

## Trade-offs

80% is a conservative starting point. Raising it closer to the current 100%
is possible once the test suite is stable, but starting strict can block
legitimate refactors. Adjust upward as confidence grows.
