### PR TITLE
fix: remove stale ZeroDivisionError test superseded by construction validation

### DIFF
--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -63,13 +63,6 @@ def test_size_aspect_ratio() -> None:
     assert SIZES["WXGA++"].aspect_ratio_two() == (16, 9)
 
 
-def test_size_aspect_ratio_zero_height() -> None:
-    with pytest.raises(ZeroDivisionError):
-        Size(1920, 0).aspect_ratio()
-    with pytest.raises(ZeroDivisionError):
-        Size(1920, 0).aspect_ratio_two()
-
-
 def test_size_scale() -> None:
     size = Size(1920, 1080)
     assert size.scale(2) == Size(3840, 2160)


### PR DESCRIPTION
## Root cause

Two commits landed in order on `main` without a cross-check:

1. **`cb75d7d`** — "Validate width and height are positive in `Size.__post_init__`": added a `__post_init__` that raises `ValueError` for any width or height `<= 0`, enforcing that only positive-dimension `Size` objects can be constructed.

2. **`a995395`** — "Fix `aspect_ratio_two()` to raise `ZeroDivisionError` when height is zero": added `test_size_aspect_ratio_zero_height`, which called `Size(1920, 0).aspect_ratio()` and `Size(1920, 0).aspect_ratio_two()` expecting `ZeroDivisionError`.

After commit 1, `Size(1920, 0)` raises `ValueError` at construction, so the `aspect_ratio*()` call paths in the test are unreachable. The test was instead catching `ValueError` from `__post_init__`, causing a mismatch and a CI failure.

## Fix

Removed `test_size_aspect_ratio_zero_height`. The zero-height rejection is already thoroughly covered by `test_size_validation_zero_height` (added alongside the `__post_init__` validation in `cb75d7d`), which asserts `ValueError` with `match="height"` for `Size(1920, 0)`. No production code was changed.

## Verification

- `uv run poe test` — 9 passed, 0 failed
- `uv run poe check` — ruff and mypy both clean