### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,31 @@ list(SIZES.keys())
 
 ## Development
 
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
 ```sh
-git clone https://github.com/kitsuyui/python-pixel-sizes.git
-cd python-pixel-sizes
+# Install dependencies
 uv sync
+
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `uv run poe check`
+- **pre-push**: `uv run poe check` and `uv run poe test`
+
+You can also run the checks manually:
+
+```sh
+uv run poe check
 uv run poe test
 ```
+
+CI still runs the full matrix (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
 
 # LICENSE
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+
+pre-push:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` to mirror the same checks CI runs (`poe check`, `poe test`) as local Git hooks on pre-commit and pre-push.
- Documents the setup in the `README.md` Development section.
- CI (GitHub Actions) is kept entirely unchanged — Actions is free for public repos; the hooks only surface problems earlier on the developer's machine.

## Changes

- **`lefthook.yml`** (new file): defines `pre-commit` (runs `poe check`) and `pre-push` (runs `poe check` + `poe test`); clears `GIT_*` environment variables before each job so nested or sibling repositories are not affected.
- **`README.md`**: expands the existing Development section with lefthook installation instructions and a description of what each hook runs.

## Verification

- `uv sync` completed without errors.
- `uv run poe check` passes (ruff + mypy clean).
- `uv run poe test` passes (9/9 tests).
- `lefthook install` succeeded; pre-commit hook fired and passed during the commit.
- pre-push hook fired and passed (check + test) during `git push`.

## Notes

- Requires `lefthook` on your PATH to use the hooks (`lefthook install` is a one-time step).
- No CI workflows were modified.
