### PR TITLE
Do not persist checkout credentials in release workflows

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         id: setup-python

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -24,6 +24,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         id: setup-python


### PR DESCRIPTION
Summary
- Disable persisted checkout credentials in the octocov workflow.
- Disable persisted checkout credentials in the packaging workflow.

Checks
- git diff --check
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color
- typos .github/workflows/octocov.yml .github/workflows/pypi-publish.yml
- uv sync --reinstall-package pixel-sizes
- uv run poe check
- uv run poe test
- uv run poe coverage-xml
- uv build

Notes
- The build command still emits existing setuptools license deprecation warnings from current project metadata.
