### PR TITLE
ci: add build provenance attestation to publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -45,6 +47,12 @@ jobs:
 
       - name: Build
         run: uv build
+
+      - name: Generate artifact attestation
+        if: github.event_name == 'release' && !github.event.release.prerelease
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: 'dist/*'
 
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
## Summary

Add build provenance attestation to the PyPI publish workflow so that released packages carry a cryptographically verifiable link back to the GitHub Actions run that built them.

## Changes

- `deploy` job permissions: add `id-token: write` and `attestations: write` alongside the existing `contents: read`
- New step **Generate artifact attestation** runs `actions/attest-build-provenance@v4.1.0` after `uv build`, conditional on non-prerelease release events only

## Motivation

Without attestation, PyPI users had no built-in way to verify that a downloaded `pixel_sizes` package was produced by this repository's public CI. GitHub's `actions/attest-build-provenance` attaches a SLSA-level provenance record that can be independently verified with `gh attestation verify`.

## Verification

- `uv run poe check` (ruff + mypy): all checks passed locally
- The attestation step only fires on non-prerelease release events; PR builds and prereleases are unaffected
