### PR TITLE
chore: add compliance workflow for secret scanning non-provider patterns

### DIFF
--- a/.github/workflows/secret-scanning-compliance.yml
+++ b/.github/workflows/secret-scanning-compliance.yml
@@ -1,0 +1,34 @@
+name: Secret Scanning Compliance
+on:
+  schedule:
+    # Weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-non-provider-patterns:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check secret_scanning_non_provider_patterns
+        run: |
+          if ! api_response=$(gh api "repos/${GITHUB_REPOSITORY}" \
+            --jq '.security_and_analysis.secret_scanning_non_provider_patterns.status' 2>&1); then
+            echo "::warning title=Compliance Check Skipped::Unable to read security settings: ${api_response}"
+            echo "The GITHUB_TOKEN may lack admin permission to read security_and_analysis. Skipping."
+            exit 0
+          fi
+          echo "secret_scanning_non_provider_patterns: ${api_response}"
+          if [ "${api_response}" = "enabled" ]; then
+            echo "Compliance check passed."
+          elif [ -z "${api_response}" ] || [ "${api_response}" = "null" ]; then
+            echo "::warning title=Compliance Check Skipped::secret_scanning_non_provider_patterns returned '${api_response}' (feature may not be available)."
+          else
+            echo "::error title=Security Compliance::secret_scanning_non_provider_patterns is '${api_response}'."
+            echo "To fix: Settings > Security > Secret scanning > Enable non-provider patterns."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Add a scheduled compliance workflow that monitors whether
`secret_scanning_non_provider_patterns` is enabled for this repository.

- Runs weekly (Monday 06:00 UTC) and on `workflow_dispatch`
- Fails with `::error` annotation if the setting is disabled, signaling
  that a human should enable it in Settings > Security > Secret scanning
- Exits 0 with `::warning` if the API call fails (network issue or token
  lacks admin permission) to avoid false positives

## Why

`secret_scanning_non_provider_patterns` detects generic high-entropy tokens
not associated with specific providers. This feature is available at no cost
for public repositories and is currently disabled. Enabling it strengthens
the detection coverage for credentials that may not be recognized by
provider-specific patterns.

The setting cannot be changed via committed code; it requires admin action
in repository Settings. This workflow creates a visible CI signal to prompt
that action.

## Test plan

- [ ] Verify workflow YAML is syntactically valid (actionlint passed)
- [ ] After enabling the setting in GitHub repository Settings, confirm the
      workflow passes on next scheduled run or manual dispatch
