### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+日本語: 脆弱性は公開 issue に書かず、下記の「Report a vulnerability」から
+非公開で報告してください。
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue or pull request containing exploit
+details.
+
+Use GitHub's private vulnerability reporting: on the repository page, go to
+**Security → Report a vulnerability**. This reaches the maintainer privately.
+
+What to include:
+
+- The affected repository and version (or commit).
+- Steps to reproduce, or a proof of concept.
+- The impact you believe it has.
+
+These are personal projects maintained in spare time. I will acknowledge
+reports as soon as I can — typically within two weeks — and coordinate a fix
+and disclosure with you. If a repository ships a published package, a fixed
+release and an advisory will follow once the fix lands.

--- a/pixel_sizes/__init__.py
+++ b/pixel_sizes/__init__.py
@@ -94,7 +94,8 @@ SIZES: MappingProxyType[str, Size] = MappingProxyType(
         "VGA": Size(640, 480),
         "SVGA": Size(800, 600),
         "WSVGA": Size(
-            1024, 600,
+            1024,
+            600,
         ),  # 2 versions exist: 1024x600 and 1024x576; using 1024x600
         "DoubleVGA": Size(960, 640),
         "XGA": Size(1024, 768),


### PR DESCRIPTION
## Summary

This repository has no security policy document. Researchers or users who
discover a vulnerability have no documented place to report it privately,
which raises the risk of public zero-day disclosure.

This PR adds `SECURITY.md` at the repository root. GitHub surfaces this
file on the **Security** tab and uses it as the entry point for
[private vulnerability reporting (PVR)](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).

## Changes

### `SECURITY.md` (new)

- Instructs reporters to use GitHub's private vulnerability reporting rather
  than opening a public issue.
- Lists what information to include in a report (affected version, repro
  steps, impact assessment).
- Sets realistic expectations: personal project, typical acknowledgement
  within two weeks, coordinated fix and advisory for published packages.

### `pixel_sizes/__init__.py` (minor)

Formatting fix applied by ruff: trailing comma on the `WSVGA` size tuple
reformatted across two lines (no logic change).

## Verification

- `ruff format` — no changes
- `ruff check` — all checks passed
- `mypy` — no issues found
- `pytest` — 9/9 tests passed
